### PR TITLE
add config parameter for additional_parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,6 +16,14 @@
 # [*internalhosts*]
 #   Inherited from params class.
 #
+# [*additional_parameters*]
+#   Hash of parameters to add to opendkim.conf file.
+#   Defaults to an empty hash.
+#   Example (in yaml for hiera):
+#
+#   opendkim::config::additional_parameters:
+#     DNSTimeout: 25
+#
 # === Examples
 #
 #   See opendkim init for complete example.
@@ -32,6 +40,7 @@ class opendkim::config(
   $umask                   = $opendkim::params::umask,
   $oversignheaders         = $opendkim::params::oversignheaders,
   $internalhosts           = $opendkim::params::internalhosts,
+  $additional_parameters   = {},
 ) inherits ::opendkim::params {
 
   concat { ['/etc/opendkim.conf', '/etc/default/opendkim', '/etc/opendkim_keytable.conf', '/etc/opendkim_signingtable.conf']:

--- a/templates/opendkim.conf.erb
+++ b/templates/opendkim.conf.erb
@@ -32,6 +32,9 @@ InternalHosts <%= @internalhosts.join(',') %>
 # (ATPS) (experimental)
 #ATPSDomains		example.com
 
+<% @additional_parameters.each do | key, value| -%>
+<%= key.ljust(20,' ') %>  <%= value %>
+<% end -%>
+
 # Sign for example.com with key in /etc/mail/dkim.key using
 # selector '2007' (e.g. 2007._domainkey.example.com)
-


### PR DESCRIPTION
This let's you use all Parameters mentioned in the manual
page of opendkim.conf