### PR TITLE
add subdomains parameter to install the key for subdomains as well

### DIFF
--- a/manifests/domain.pp
+++ b/manifests/domain.pp
@@ -35,6 +35,7 @@ define opendkim::domain(
   $key_folder          = '/etc/dkim',
   $signing_key         = $name,
   $user                = $opendkim::params::user,
+  $subdomains          = false,
 ) {
 
   if (empty($private_key_source) and empty($private_key_content)) {
@@ -65,6 +66,14 @@ define opendkim::domain(
     content => "${signing_key} ${selector}._domainkey.${domain}\n",
     order   => 10,
     require => File[$key_file],
+  }
+  if ($subdomains) {
+    concat::fragment{ "signingtable_${name}_subdomains":
+      target  => '/etc/opendkim_signingtable.conf',
+      content => ".${signing_key} ${selector}._domainkey.${domain}\n",
+      order   => 10,
+      require => File[$key_file],
+    }
   }
   concat::fragment{ "keytable_${name}":
     target  => '/etc/opendkim_keytable.conf',

--- a/spec/defines/opendkim_domain_spec.rb
+++ b/spec/defines/opendkim_domain_spec.rb
@@ -40,5 +40,39 @@ describe 'opendkim::domain', :type => :define do
           )
         end
     end
+    describe 'for example.com domain with custom selector and subdomains' do
+        let(:params) do
+            default_params.merge( {
+                :selector    => 'testselector',
+                :subdomains  => true,
+            } )
+        end
+        it do
+            should contain_file('/etc/dkim/testselector-example.com.key').with(
+                :source => 'puppet:///path/to/example.com.key',
+                :owner  => 'opendkim',
+                :group  => 'root',
+                :mode   => '0600',
+            )
+        end
+        it do
+            should contain_concat__fragment('keytable_example.com').with(
+                'target'  => '/etc/opendkim_keytable.conf',
+                'content' => %r{^testselector._domainkey.example.com\sexample.com:testselector:/etc/dkim/testselector-example.com.key}m,
+            )
+        end
+        it do
+          should contain_concat__fragment('signingtable_example.com').with(
+            'target'  => '/etc/opendkim_signingtable.conf',
+            'content' => %r{^example.com\stestselector._domainkey.example.com}m,
+          )
+        end
+        it do
+          should contain_concat__fragment('signingtable_example.com_subdomains').with(
+            'target'  => '/etc/opendkim_signingtable.conf',
+            'content' => %r{^\.example\.com\stestselector\._domainkey\.example\.com}m,
+          )
+        end
+    end
 end
 


### PR DESCRIPTION
When subdomains is set to true, the key will be added to the signing table for subdomains as well as the main domain.